### PR TITLE
Bugfixes

### DIFF
--- a/src/main/java/de/minebench/simpleplayerregions/commands/DefineCommandExecutor.java
+++ b/src/main/java/de/minebench/simpleplayerregions/commands/DefineCommandExecutor.java
@@ -77,7 +77,7 @@ public class DefineCommandExecutor implements CommandExecutor {
         int yMin = plugin.getMinY();
         int yMax = plugin.getMaxY();
         if(sender.hasPermission(command.getPermission() + ".setymin")) {
-            yMax = selection.getNativeMinimumPoint().getBlockY();
+            yMin = selection.getNativeMinimumPoint().getBlockY();
         } else {
             pntMin.setY(plugin.getMinY());
         }
@@ -88,11 +88,12 @@ public class DefineCommandExecutor implements CommandExecutor {
         }
 
         ProtectedRegion region;
-        String regionName = getRegionName(playerName).toLowerCase();
+        String regionBaseName = getRegionName(playerName).toLowerCase();
+        String regionName = regionBaseName;
         int i = 0;
         while(regions.hasRegion(regionName)) {
             i++;
-            regionName += "_" + i;
+            regionName = regionBaseName + "_" + i;
         }
         if(selection instanceof CuboidSelection) {
             region = new ProtectedCuboidRegion(regionName, pntMin, pntMax);


### PR DESCRIPTION
- Es wurde yMax statt yMin gesetzt. Das hat nur einen Effekt, wenn der Spieler die .setymin Permission hat und eine Poly-Region erstellt.
- Die Suffixe für bereits existierende Regionen waren "_1", "_1_2", "_1_2_3", usw. statt "_1", "_2", ...

Ich hab den online Editor von GitHub benutzt, also teste es lieber nochmal xD
